### PR TITLE
Addressing text wrap issue in AutorunsToWinEventLog

### DIFF
--- a/AutorunsToWinEventLog/AutorunsToWinEventLog.ps1
+++ b/AutorunsToWinEventLog/AutorunsToWinEventLog.ps1
@@ -29,6 +29,6 @@ $proc.WaitForExit()
 $autorunsArray = Import-Csv $autorunsCsv
 
 Foreach ($item in $autorunsArray) {
-  $item = $(Write-Output $item  | Out-String)
+  $item = $(Write-Output $item  | Out-String -Width 1000)
   Write-EventLog -LogName Autoruns -Source AutorunsToWinEventLog -EntryType Information -EventId 1 -Message $item
 }


### PR DESCRIPTION
Resolves the issue described in https://github.com/palantir/windows-event-forwarding/issues/15