### PR TITLE
Removing guidance to enable auditing of privilege use

### DIFF
--- a/group-policy-objects/README.md
+++ b/group-policy-objects/README.md
@@ -307,8 +307,6 @@ Set the following setting **Computer Configuration -> Policies -> Windows Settin
 * **Audit Authentication Policy Change**: Success, Failure
 * **Audit MPSSVC Rule-Level Policy Change**: Success, Failure
 * **Audit Other Policy Change Events**: Success, Failure
-* **Audit Non Sensitive Privilege Use**: Failure
-* **Audit Sensitive Privilege Use**: Success, Failure
 * **Audit Other System Events**: Success, Failure
 * **Audit Security State Change**: Success, Failure
 * **Audit Security System Extension**: Success, Failure


### PR DESCRIPTION
This auditing control is responsible for the generation of Event Code 4674 events, which can be extremely noisy in certain environments.