### PR TITLE
Update Windows-Defender.xml

### DIFF
--- a/wef-subscriptions/Windows-Defender.xml
+++ b/wef-subscriptions/Windows-Defender.xml
@@ -22,6 +22,14 @@
         <!-- Modern Windows Defender event provider Detection events (1006-1009) and (1116-1119) -->
         <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[( (EventID &gt;= 1006 and EventID &lt;= 1009) )]]</Select>
         <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[( (EventID &gt;= 1116 and EventID &lt;= 1119) )]]</Select>
+        <!-- 1120: Windows Defender Antivirus has deduced the hashes for a threat resource (requires registry activation). -->
+        <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=1120)]]</Select>
+        <!-- 5001: Windows Defender Real-time protection is disabled. -->
+        <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=5001)]]</Select>
+        <!-- 5000: Windows Defender Real-time protection is enabled. -->
+        <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=5000)]]</Select>
+        <!-- 5004: Windows Defender The real-time protection configuration changed (enabled or disabled component). -->
+        <Select Path="Microsoft-Windows-Windows Defender/Operational">*[System[(EventID=5001)]]</Select>
       </Query>
     </QueryList>]]></Query>
   <ReadExistingEvents>true</ReadExistingEvents>


### PR DESCRIPTION
I'm adding the following Windows Defender events as they can be valuable for SOC use cases or Threat hunting:
ID 1120: when properly activated in the registry, Windows Defender will provide a hash of the threat
ID 5001: if protection Defender Real time protection was disabled on the host, this event will be triggered
ID 5000: if protection Defender Real time protection was enabled on the host, this event will be triggered. It may be interesting to collect it in order to check how long was the protection disabled (or even to limit the amount of false positive).
ID 5004: is triggered when some components of Windows Defender are disabled with the following commands (Set-MpPreference -DisableBehaviorMonitoring $true OR Set-MpPreference -DisableIOAVProtection $true)

https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/troubleshoot-windows-defender-antivirus