### PR TITLE
Update default log file size

### DIFF
--- a/windows-event-channels/README.md
+++ b/windows-event-channels/README.md
@@ -120,7 +120,7 @@ wevtutil im C:\windows\system32\CustomEventChannels.man
 ```
 $xml = wevtutil el | select-string -pattern "WEC"
     foreach ($subscription in $xml) {
-      wevtutil sl $subscription /ms:4194304
+      wevtutil sl $subscription /ms:4294967296
     }
 ```
 


### PR DESCRIPTION
I propose resizing the log files to a more sane 4GB instead of 4MB.
Beginning with 4MB will cause the loss of lots of log files when event collection is enabled for the first time.